### PR TITLE
Remove deprecated `sudo` key from `.travis.yml`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
+---
 language: php
-
 php:
   - 7.1
   - 7.2
 
-sudo: false
-
 cache:
-   directories:
-     - $HOME/.composer/cache/files
+  directories:
+    - $HOME/.composer/cache/files
 
 before_script: composer install
 

--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,10 @@
         "classmap": [
             "src/"
         ]
+    },
+    "support": {
+        "issues": "https://github.com/DanielRuf/secure-shred/issues",
+        "source": "https://github.com/DanielRuf/secure-shred",
+        "docs": "https://github.com/DanielRuf/secure-shred/blob/master/README.md"
     }
 }


### PR DESCRIPTION
Travis CI now routes builds to the Ubuntu Trusty sudoless VM images by
default, and has officially deprecated the `sudo: false` declaration in
their `.travis.yml` files. See the Travis CI blog for more information:

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

This commit also adds a few `support` URLs to the `composer.json` file.