### PR TITLE
Improve checking the file's status before shredding

### DIFF
--- a/src/Shred.php
+++ b/src/Shred.php
@@ -114,14 +114,15 @@ final class Shred
    * @param string $filepath
    * @return bool
    */
-  private function fileWritable($filepath) {
-
+  private function fileWritable($filepath)
+  {
     // clear stat cache to avoid falsely reported file status
     // use $filename parameter to possibly improve performance
     clearstatcache(true, $filepath);
 
-    if (file_exists($filepath) && is_file($filepath)
-      && is_readable($filepath) && is_writable($filepath)) {
+    if (is_file($filepath)
+      && is_readable($filepath)
+      && is_writable($filepath)) {
       return true;
     }
 

--- a/src/Shred.php
+++ b/src/Shred.php
@@ -114,9 +114,14 @@ final class Shred
    * @param string $filepath
    * @return bool
    */
-  private function fileWritable($filepath)
-  {
-    if (is_readable($filepath) && is_writable($filepath)) {
+  private function fileWritable($filepath) {
+
+    // clear stat cache to avoid falsely reported file status
+    // use $filename parameter to possibly improve performance
+    clearstatcache(true, $filepath);
+
+    if (file_exists($filepath) && is_file($filepath)
+      && is_readable($filepath) && is_writable($filepath)) {
       return true;
     }
 

--- a/tests/ShredTest.php
+++ b/tests/ShredTest.php
@@ -70,6 +70,19 @@ final class ShredTest extends TestCase
     );
   }
 
+  public function testCanNotShredDirectory()
+  {
+    $shred = new Shred\Shred();
+
+    $this->assertFalse(
+      $shred->shred(vfsStream::url("{$this->rootName}/{$this->testFolder}"), true)
+    );
+
+    $this->assertFileExists(
+      vfsStream::url("{$this->rootName}/{$this->testFolder}")
+    );
+  }
+
   public function testStats()
   {
     $file = file_get_contents(vfsStream::url("{$this->rootName}/{$this->testFile}"));


### PR DESCRIPTION
Improve checking a file's status by

- clearing PHP's [stat cache](https://secure.php.net/manual/de/function.clearstatcache.php) for the specific file
- checking if it actually is a file, otherwise could be a directory